### PR TITLE
Editorial changes - terminology issue ('gesture')

### DIFF
--- a/SCs/m3.md
+++ b/SCs/m3.md
@@ -4,10 +4,11 @@ Pointer gestures
 
 # SC Text
 
-All functionality can be operated without requiring precise/timed pointer gestures or multi-pointer gestures.
+All functionality can be operated without requiring  complex or timed pointer gestures or multi-pointer gestures.
 
-Note 1: examples of a multi-pointer gesture include two-finger pinch/zoom
-Note 2: this requirement applies to web content which interprets pointer gestures (i.e. this does not apply to gestures that are required to operate the user agent or assistive technology)
+Note 1: Examples of a multi-pointer gesture include two-finger pinch/zoom
+
+Note 2: This requirement applies to web content which interprets pointer gestures (i.e. this does not apply to gestures that are required to operate the user agent or assistive technology)
 
 # Suggestion for Priority Level (A/AA/AAA)
 
@@ -23,20 +24,20 @@ Principle 2, *new* Guideline "Pointer Accessible"
 
 # Description
 
-It may not always be possible for users to perform specific gestures (e.g. draw a complex path with their finger on a touchscreen) in a precise and timely manner - they may lack the precision/accuracy/speed necessary. Further, it may not always be possible for users to perform multi-pointer gestures (e.g. a two-finger pinch/zoom, three-finger rotation). Authors must ensure that their content/functionality can be operated without requiring the user to perform specific gestures.
+It may not always be possible for users to perform specific gestures (e.g. draw a complex path with their finger on a touchscreen) in a precise and timely manner - they may lack the precision/accuracy/speed necessary. Further, it may not always be possible for users to perform multi-pointer gestures (e.g. a two-finger pinch/zoom, three-finger rotation). Authors must ensure that their content/functionality can be operated without requiring the user to perform timed or complex gestures.
 
-Note: this does not preclude the inclusion of gesture-based interactions; however, if gesture-based controls are used, then a non-gesture-based alternative which only requires a single activation/tap must be present.
+Note: this does not preclude the inclusion of gesture-based interactions; however, if gesture-based controls are used, then an alternative which only requires a single activation/tap must be present.
 
 # Benefits
 
-Users who cannot (accurately) perform pointer gestures (such as touchscreen swipes or multi-pointer gestures such as a two-finger pinch/zoom) will be able to operate content/functionality.
+Users who cannot (accurately) perform complex or timed pointer gestures (such as touchscreen swipes or multi-pointer gestures such as a two-finger pinch/zoom) will be able to operate content/functionality.
 
 # Testability
 
-Manual test: if a web site/application provides gesture-based controls, ensure that non-gesture-based alternatives are available.
+Manual test: if a web site/application has controls that accept complex or timed pointer gestures, ensure that the functionality can be operated via alternative simple controls that can be activated by a simple pointer gesture (such as tapping or a mouse click).
 
 # Techniques
 
-Don't rely solely on pointer gestures that require high precision or specific timings; don't rely on multi-pointer gestures; provide alternatives that do not require gestures (e.g. additional visible controls that perform the same/similar action as a quick flick/swipe) and alternatives that only require a single pointer, rather than multi-pointer.
+Do not rely solely on complex pointer gestures that require high precision or specific timings; do not rely on multi-pointer gestures; provide alternatives that do not require complex gestures (e.g. additional visible controls that perform the same function as a complex gesture and can be activated by a simple pointer gesture (mouse click, tap).
 
 [Note: the techniques M3 and M9 are related and may be combined in 2.1. M3 requires that functionality work without timing or multi gestures, M9 requires it works without tilt, specific pressure, or angle, etc...]


### PR DESCRIPTION
Terminology: It is quite common to see simple touch operations like a single tap referred to as gesture. For me it is not clear where 'gesture' starts. I don't think it is evident and common-sense that 'gesture' would not include single tap activation. So talking about a "non-gesture-based alternative" seems problematic if we mwean that theae should be controls that can be activated by single tap (or, with AT on, swipe followed double tap or alternatively, a split tap).

Consequently I have tried to reword verious parts of this SC to refer to "complex or timed pointer gestures or multi-pointer gestures" as opposed to simple pointer gesture (such as tapping or a mouse click).

Do we need to spell out that this SC applies to touch interfaces with built-in AT not active? Or have it apply generally but spell out that complex gestures usuall do not work when AT is on unless pass-through gestures are used (which often do not work reliably)?

Another issue:  Note 2 refers to "web content" - does this preclude applicability of the SC to native apps?